### PR TITLE
Support arbitrary aspect ratio for thumbnails

### DIFF
--- a/light-gallery/css/lightGallery.css
+++ b/light-gallery/css/lightGallery.css
@@ -407,7 +407,7 @@
   *zoom: 1;
 	margin-bottom: 4px;
 	margin-left: 4px;
-	width: 50px;
+	height: 50px;
 	opacity: 0.6;
 	filter: alpha(opacity=60);
 	overflow: hidden;
@@ -422,12 +422,12 @@
 }
 @media (min-width: 800px) {
 #lightGallery-Gallery .thumb_cont .thumb {
-	width: 94px;
+	height: 94px;
 }
 }
 #lightGallery-Gallery .thumb_cont .thumb > img {
-	height: auto;
-	max-width: 100%;
+	max-height: 100%;
+	min-height: 100%;
 	display: block;
 }
 #lightGallery-Gallery .thumb_cont .thumb.active, #lightGallery-Gallery .thumb_cont .thumb:hover {


### PR DESCRIPTION
It would be nice if thumbnails could be of any aspect ratio, not just square. 
This would reduce the time needed for authors to prepare their pictures for publishing.
Removing fixed height for `img` containers and giving them `display:block` to remove bottom padding seems to be sufficient.

![image](https://cloud.githubusercontent.com/assets/45722/2877790/3bc45a70-d453-11e3-921a-e1140d29222d.png)
![image](https://cloud.githubusercontent.com/assets/45722/2877795/40ddb376-d453-11e3-8aff-d227935324ff.png)
