### PR TITLE
Support configuration of event propagation stopping.

### DIFF
--- a/demo/lightGallery.js
+++ b/demo/lightGallery.js
@@ -28,6 +28,7 @@
                 preload: 1, //number of preload slides. will exicute only after the current slide is fully loaded. ex:// you clicked on 4th image and if preload = 1 then 3rd slide and 5th slide will be loaded in the background after the 4th slide is fully loaded.. if preload is 2 then 2nd 3rd 5th 6th slides will be preloaded.. ... ...
                 showAfterLoad: true,
                 selector: null,
+                stopPropagation: true,
                 index: false,
 
                 lang: {
@@ -99,7 +100,9 @@
                                 $children = $this.children();
                             }
                             e.preventDefault();
-                            e.stopPropagation();
+                            if (settings.stopPropagation) {
+                                e.stopPropagation();
+                            }
                             index = $children.index(this);
                             prevIndex = index;
                             setUp.init(index);
@@ -225,12 +228,16 @@
                 var xStart, xEnd;
                 var $this = this;
                 $('.lightGallery').bind('mousedown', function(e) {
-                    e.stopPropagation();
+                    if (settings.stopPropagation) {
+                        e.stopPropagation();
+                    }
                     e.preventDefault();
                     xStart = e.pageX;
                 });
                 $('.lightGallery').bind('mouseup', function(e) {
-                    e.stopPropagation();
+                    if (settings.stopPropagation) {
+                        e.stopPropagation();
+                    }
                     e.preventDefault();
                     xEnd = e.pageX;
                     if (xEnd - xStart > 20) {
@@ -554,7 +561,9 @@
                 var $this = this;
                 $(window).bind('keyup.lightGallery', function(e) {
                     e.preventDefault();
-                    e.stopPropagation();
+                    if (settings.stopPropagation) {
+                        e.stopPropagation();
+                    }
                     if (e.keyCode === 37) {
                         $this.prevSlide();
                         clearInterval(interval);

--- a/light-gallery/js/lightGallery.js
+++ b/light-gallery/js/lightGallery.js
@@ -28,6 +28,7 @@
                 preload: 1, //number of preload slides. will exicute only after the current slide is fully loaded. ex:// you clicked on 4th image and if preload = 1 then 3rd slide and 5th slide will be loaded in the background after the 4th slide is fully loaded.. if preload is 2 then 2nd 3rd 5th 6th slides will be preloaded.. ... ...
                 showAfterLoad: true,
                 selector: null,
+                stopPropagation: true,
                 index: false,
 
                 lang: {
@@ -99,7 +100,9 @@
                                 $children = $this.children();
                             }
                             e.preventDefault();
-                            e.stopPropagation();
+                            if (settings.stopPropagation) {
+                                e.stopPropagation();
+                            }
                             index = $children.index(this);
                             prevIndex = index;
                             setUp.init(index);
@@ -225,12 +228,16 @@
                 var xStart, xEnd;
                 var $this = this;
                 $('.lightGallery').bind('mousedown', function(e) {
-                    e.stopPropagation();
+                    if (settings.stopPropagation) {
+                        e.stopPropagation();
+                    }
                     e.preventDefault();
                     xStart = e.pageX;
                 });
                 $('.lightGallery').bind('mouseup', function(e) {
-                    e.stopPropagation();
+                    if (settings.stopPropagation) {
+                        e.stopPropagation();
+                    }
                     e.preventDefault();
                     xEnd = e.pageX;
                     if (xEnd - xStart > 20) {
@@ -554,7 +561,9 @@
                 var $this = this;
                 $(window).bind('keyup.lightGallery', function(e) {
                     e.preventDefault();
-                    e.stopPropagation();
+                    if (settings.stopPropagation) {
+                        e.stopPropagation();
+                    }
                     if (e.keyCode === 37) {
                         $this.prevSlide();
                         clearInterval(interval);


### PR DESCRIPTION
There are situations where allowing events to propagate is desirable (e.g. even tracking).  This keeps the current behaviour (stopping all event propagation) as the default, but allows users to disable it if they prefer.

I'm not sure how you're minifying things, so I haven't updated the .min.js files.

I'm not sure that preventing propagation really makes sense as a default option, but I've elected to keep it for backwards compatibility.  Feel free to change the default to be not to prevent propagation if you're confident that this will not break things.