### PR TITLE
Use non-responsive data-src fallback when no data-responsive-src is found

### DIFF
--- a/light-gallery/js/lightGallery.js
+++ b/light-gallery/js/lightGallery.js
@@ -342,7 +342,10 @@
                     } else {
                         src = $children.eq(index).attr('data-responsive-src');
                     }
-                } else {
+                }
+
+                // Fall back to use non-responsive source if no responsive source was found
+                if (!src) {
                     if (settings.dynamic) {
                         src = settings.dynamicEl[index].src;
                     } else {


### PR DESCRIPTION
This approach is more tolerant of errors (where data-src is present and no data-responsive-src) and avoids duplication of data-src and data-responsive-src when a particular element doesn't require a responsive source.