### PR TITLE
Removed Hardcoded HTTP Schema for Vimeo

### DIFF
--- a/src/js/lg-thumbnail.js
+++ b/src/js/lg-thumbnail.js
@@ -184,7 +184,7 @@
             var vimeoVideoId = $this.attr('data-vimeo-id');
 
             if (vimeoVideoId) {
-                $.getJSON('http://www.vimeo.com/api/v2/video/' + vimeoVideoId + '.json?callback=?', {
+                $.getJSON('//www.vimeo.com/api/v2/video/' + vimeoVideoId + '.json?callback=?', {
                     format: 'json'
                 }, function(data) {
                     $this.find('img').attr('src', data[0][_this.core.s.vimeoThumbSize]);

--- a/src/js/lg-video.js
+++ b/src/js/lg-video.js
@@ -242,7 +242,7 @@
                 a = a + '&' + $.param(this.core.s.vimeoPlayerParams);
             }
 
-            video = '<iframe class="lg-video-object lg-vimeo ' + addClass + '" width="560" height="315"  src="http://player.vimeo.com/video/' + isVideo.vimeo[1] + a + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
+            video = '<iframe class="lg-video-object lg-vimeo ' + addClass + '" width="560" height="315"  src="//player.vimeo.com/video/' + isVideo.vimeo[1] + a + '" frameborder="0" webkitAllowFullScreen mozallowfullscreen allowFullScreen></iframe>';
 
         } else if (isVideo.dailymotion) {
 


### PR DESCRIPTION
As the code stands, the vimeo player has a hardcoded `http://`in the URL. When deployed on HTTPS/SSL, the browser prevents the player from loading due to insecure origin policies.

This fix utilizes the `//` mechanism to dynamically determine the protocol from the page running it. The YouTube and DailyMotion videos *already* were loaded like this, it was only Vimeo that was not.