### PR TITLE
When hash disabled, still changes hash on destroy

### DIFF
--- a/dist/js/lg-hash.js
+++ b/dist/js/lg-hash.js
@@ -49,6 +49,8 @@
 
     Hash.prototype.destroy = function() {
 
+        if (this.core.s.hash != true) return;
+
         // Reset to old hash value
         if (this.oldHash && this.oldHash.indexOf('lg=' + this.core.s.galleryId) < 0) {
             window.location.hash = this.oldHash;


### PR DESCRIPTION
When hash plugin disabled, it's destroy method still called by main lightgallery.js. Once this method called, it clears any active hash on the browser. This fix should check if hash used in lightgallery and then run it's destroy method.