### PR TITLE
Thumbnail images now in "object-fit: cover;" mode to avoid distortion.

### DIFF
--- a/src/css/lightgallery.css
+++ b/src/css/lightgallery.css
@@ -322,6 +322,7 @@ body:not(.lg-from-hash) .lg-outer.lg-start-zoom .lg-item.lg-complete .lg-object 
 .lg-outer .lg-thumb-item img {
   width: 100%;
   height: 100%;
+  object-fit: cover;
 }
 .lg-outer.lg-has-thumb .lg-item {
   padding-bottom: 120px;


### PR DESCRIPTION
While setting up lightGallery with the **thumbnail** plugin, I noticed that thumbnails get distorted as they are formatted to the thumbnail size.
Adding _object-fit: cover;_ to the CSS properties fixes this.