### PR TITLE
Use caption of the lightgallery selector.

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -449,8 +449,10 @@
      *  @param {Number} index - index of the slide
      */
     Plugin.prototype.addHtml = function(index) {
-        var subHtml = null;
-        var subHtmlUrl;
+        var subHtml = null,
+            subHtmlSelf,
+            subHtmlUrl,
+            $currentEle = this.$items.eq(index);
         if (this.s.dynamic) {
             if (this.s.dynamicEl[index].subHtmlUrl) {
                 subHtmlUrl = this.s.dynamicEl[index].subHtmlUrl;
@@ -458,13 +460,14 @@
                 subHtml = this.s.dynamicEl[index].subHtml;
             }
         } else {
-            if (this.$items.eq(index).attr('data-sub-html-url')) {
-                subHtmlUrl = this.$items.eq(index).attr('data-sub-html-url');
+            if ($currentEle.attr('data-sub-html-url')) {
+                subHtmlUrl = $currentEle.attr('data-sub-html-url');
             } else {
 
-                subHtml = this.$items.eq(index).attr('data-sub-html');
+                subHtml = $currentEle.attr('data-sub-html');
+                subHtmlSelf = $currentEle.attr('data-sub-html-self');
                 if (this.s.getCaptionFromTitleOrAlt && !subHtml) {
-                    subHtml = this.$items.eq(index).attr('title') || this.$items.eq(index).find('img').first().attr('alt');
+                    subHtml = $currentEle.attr('title') || $currentEle.find('img').first().attr('alt');
                 }
             }
         }
@@ -476,7 +479,11 @@
                 // if first letter starts with . or # get the html form the jQuery object
                 var fL = subHtml.substring(0, 1);
                 if (fL === '.' || fL === '#') {
-                    subHtml = $(subHtml).html();
+                    if (subHtmlSelf) {
+                        subHtml = $currentEle.find(subHtml).html();     
+                    } else {
+                        subHtml = $(subHtml).html();                        
+                    }
                 }
             } else {
                 subHtml = '';


### PR DESCRIPTION
```
<script>
$('#images').lightGallery({
    selector: '.image'
}); 
</script>

<div id="images">
  <div class="image" data-src="bigImg.jpg" data-sub-html=".caption" data-sub-html-self="true">
     <img src="img.jpg"/>
     <div class="caption">
          <h3>Image Title</h3>
          <p>Image Text</p>
     </div>
  </div>
  <div class="image" data-src="bigImg2.jpg" data-sub-html=".caption" data-sub-html-self="true">
     <img src="img2.jpg"/>
     <div class="caption">
          <h3>Image Title 2</h3>
          <p>Image Text 2</p>
     </div>
  </div>
</div>
```
With this change it is possible to use the "sub-html" of the current element therefore you don't have to search a specific selector within the whole dom and without a unique identifier. 
Benefits: no unique identifier needed, caption is within the lightgallery selector, faster because you don't have to find the element within the whole DOM

Thx for the nice library!