### PR TITLE
lists out assets for webpack

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,8 +5,14 @@
     "main": [
         "dist/js/lightgallery.min.js",
         "dist/css/lightgallery.css",
-        "dist/fonts/*",
-        "dist/img/*"
+        "dist/fonts/lg.eot",
+        "dist/fonts/lg.svg",
+        "dist/fonts/lg.ttf",
+        "dist/fonts/lg.woff",
+        "dist/img/loading.gif",
+        "dist/img/video-play.png",
+        "dist/img/vimeo-play.png",
+        "dist/img/youtube-play.png"
     ],
     "keywords": [
         "gallery",


### PR DESCRIPTION
If you are trying to package lightGallery via webpack, it errors when trying to package the fonts and images since webpack doesnt support blobs. By listing them out in the bower.json file webpack can find a n package the library normally