### PR TITLE
Fix typo of the toggle class

### DIFF
--- a/src/sass/lg-thumbnail.scss
+++ b/src/sass/lg-thumbnail.scss
@@ -85,7 +85,7 @@
         }
     }
 
-    .lg-toogle-thumb {
+    .lg-toggle-thumb {
         background-color: $lg-thumb-toggle-bg;
         border-radius: $lg-border-radius-base $lg-border-radius-base 0 0;
         color: $lg-thumb-toggle-color;


### PR DESCRIPTION
The thumbnail plugin inject a span with class 'lg-toggle-thumb'
This type causes the non appearing of the icon