### PR TITLE
Drop IE6/IE7 clearfix method

### DIFF
--- a/src/sass/lightgallery.scss
+++ b/src/sass/lightgallery.scss
@@ -12,17 +12,9 @@
 @import "lg-share";
 
 // Clearfix
-.group {
-    *zoom: 1;
-}
-
-.group:before, .group:after {
-    display: table;
-    content: "";
-    line-height: 0;
-}
-
 .group:after {
+    content: "";
+    display: table;
     clear: both;
 }
 


### PR DESCRIPTION
`*zoom: 1` doesn't do anything in IE8+, and lightGallery only supports IE8+, so I think it makes perfect sense to update the clearfix too.

http://stackoverflow.com/questions/211383/what-methods-of-clearfix-can-i-use
