### PR TITLE
Improve action button markup

### DIFF
--- a/src/css/lightgallery.css
+++ b/src/css/lightgallery.css
@@ -20,12 +20,14 @@
 
 .lg-actions .lg-next, .lg-actions .lg-prev {
   background-color: rgba(0, 0, 0, 0.45);
+  border: none;
   border-radius: 2px;
   color: #999;
   cursor: pointer;
   display: block;
   font-size: 22px;
   margin-top: -10px;
+  outline: none;
   padding: 8px 10px 9px;
   position: absolute;
   top: 50%;

--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -271,8 +271,8 @@
         // Create controlls
         if (this.s.controls && this.$items.length > 1) {
             controls = '<div class="lg-actions">' +
-                '<div class="lg-prev lg-icon">' + this.s.prevHtml + '</div>' +
-                '<div class="lg-next lg-icon">' + this.s.nextHtml + '</div>' +
+                '<button class="lg-prev lg-icon">' + this.s.prevHtml + '</button>' +
+                '<button class="lg-next lg-icon">' + this.s.nextHtml + '</button>' +
                 '</div>';
         }
 


### PR DESCRIPTION
Until now `div` elements were used for the action „buttons“.
Let’s actually use `button` elements for these.

Especially because the `arrowDisable` function assigns the `disabled` attribute to the elements which is only supported for `input` elements.