### PR TITLE
Add events for Fullscreen module

### DIFF
--- a/modules/lg-fullscreen.js
+++ b/modules/lg-fullscreen.js
@@ -58,6 +58,9 @@
     };
 
     Fullscreen.prototype.requestFullscreen = function() {
+        // trigger onBeforeFullscreen.lg event
+        this.$el.trigger('onBeforeFullscreen.lg');
+
         var el = document.documentElement;
         if (el.requestFullscreen) {
             el.requestFullscreen();
@@ -68,9 +71,15 @@
         } else if (el.webkitRequestFullscreen) {
             el.webkitRequestFullscreen();
         }
+
+        // trigger onAfterFullscreen.lg event
+        this.$el.trigger('onAfterFullscreen.lg');
     };
 
     Fullscreen.prototype.exitFullscreen = function() {
+        // trigger onBeforeExifFullscreen.lg event
+        this.$el.trigger('onBeforeExifFullscreen.lg');
+
         if (document.exitFullscreen) {
             document.exitFullscreen();
         } else if (document.msExitFullscreen) {
@@ -80,6 +89,9 @@
         } else if (document.webkitExitFullscreen) {
             document.webkitExitFullscreen();
         }
+
+        // trigger onAfterExifFullscreen.lg event
+        this.$el.trigger('onAfterExifFullscreen.lg');
     };
 
     // https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Using_full_screen_mode


### PR DESCRIPTION
1. onBeforeFullscreen.lg
2. onAfterFullscreen.lg
3. onBeforeExifFullscreen.lg
4. onAfterExifFullscreen.lg

The reason for add these events is that when user add data-sub-html for comments, he can use these events for show or hide comments when enter or exit fullscreen mode.