### PR TITLE
Prevent url replacing on open, preserving history

### DIFF
--- a/modules/lg-hash.js
+++ b/modules/lg-hash.js
@@ -46,7 +46,7 @@
 
         // Change hash value on after each slide transition
         _this.core.$el.on('onAfterSlide.lg.tm', function(event, prevIndex, index) {
-            if (history.replaceState) {
+            if (history.replaceState && prevIndex !== index) {
                 history.replaceState(null, null, window.location.pathname + window.location.search + '#lg=' + _this.core.s.galleryId + '&slide=' + index);
             } else {
                 window.location.hash = 'lg=' + _this.core.s.galleryId + '&slide=' + index;


### PR DESCRIPTION
If light gallery is opened it replaces the current url.
When the user wants to go back, users go back to the page before the one containing the gallery.
When lightGallery is opened prevIndex and index are the same.
Then we do not want to replace the state, but instead push a new state to the history.