### PR TITLE
Fix cache-busting for the EOT font file

### DIFF
--- a/src/sass/lg-fonts.scss
+++ b/src/sass/lg-fonts.scss
@@ -2,7 +2,7 @@
 @font-face {
     font-family: 'lg';
     src: url("#{$lg-path-fonts}/lg.eot?n1z373");
-    src: url("#{$lg-path-fonts}/lg.eot?#iefixn1z373") format("embedded-opentype"), url("#{$lg-path-fonts}/lg.woff?n1z373") format("woff"), url("#{$lg-path-fonts}/lg.ttf?n1z373") format("truetype"), url("#{$lg-path-fonts}/lg.svg?n1z373#lg") format("svg");
+    src: url("#{$lg-path-fonts}/lg.eot?n1z373#iefix") format("embedded-opentype"), url("#{$lg-path-fonts}/lg.woff?n1z373") format("woff"), url("#{$lg-path-fonts}/lg.ttf?n1z373") format("truetype"), url("#{$lg-path-fonts}/lg.svg?n1z373#lg") format("svg");
     font-weight: normal;
     font-style: normal;
 }


### PR DESCRIPTION
The cache busting argument must be part of the query string, not of the fragment, as we want it to be sent to the server