### PR TITLE
Fix Document not active Exception in lg-fullscreen.js

### DIFF
--- a/modules/lg-fullscreen.js
+++ b/modules/lg-fullscreen.js
@@ -80,7 +80,7 @@
     };
 
     Fullscreen.prototype.exitFullscreen = function() {
-        if (document.exitFullscreen) {
+        if (document.fullscreenElement) {
             document.exitFullscreen();
         } else if (document.msExitFullscreen) {
             document.msExitFullscreen();


### PR DESCRIPTION
Changing document.exitFullscreen to document.fullscreenElement helped in my case to beat Document not active Exception during programatically destroying ligthgallery component