### PR TITLE
docs: Fix simple typo, exicute -> execute

### DIFF
--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -44,7 +44,7 @@
 
         /**
          * @desc number of preload slides
-         * will exicute only after the current slide is fully loaded.
+         * will execute only after the current slide is fully loaded.
          *
          * @ex you clicked on 4th image and if preload = 1 then 3rd slide and 5th
          * slide will be loaded in the background after the 4th slide is fully loaded..


### PR DESCRIPTION
There is a small typo in src/js/lightgallery.js.

Should read `execute` rather than `exicute`.

