### PR TITLE
added support for youtube parameters in URL

### DIFF
--- a/modules/lg-video.js
+++ b/modules/lg-video.js
@@ -120,6 +120,9 @@
                 if (this.core.s.youtubePlayerParams) {
                     a = a + '&' + $.param(this.core.s.youtubePlayerParams);
                 }
+                if (isVideo.youtube[2]) {
+                    a = a + isVideo.youtube[2].replace('?','&');
+                }
 
                 video = '<iframe class="lg-video-object lg-youtube ' + addClass + '" ' + videoTitle + ' width="560" height="315" src="//www.youtube.com/embed/' + isVideo.youtube[1] + a + '" frameborder="0" allowfullscreen></iframe>';
 

--- a/src/js/lightgallery.js
+++ b/src/js/lightgallery.js
@@ -421,7 +421,7 @@
      *  @desc Check the given src is video
      *  @param {String} src
      *  @return {Object} video type
-     *  Ex:{ youtube  :  ["//www.youtube.com/watch?v=c0asJgSyxcY", "c0asJgSyxcY"] }
+     *  Ex:{ youtube  :  ["//www.youtube.com/watch?v=c0asJgSyxcY?param1=1", "c0asJgSyxcY", "?param1=1"] }
      */
     Plugin.prototype.isVideo = function(src, index) {
 
@@ -443,7 +443,7 @@
             }
         }
 
-        var youtube = src.match(/\/\/(?:www\.)?youtu(?:\.be|be\.com|be-nocookie\.com)\/(?:watch\?v=|embed\/)?([a-z0-9\-\_\%]+)/i);
+        var youtube = src.match(/\/\/(?:www\.)?youtu(?:\.be|be\.com|be-nocookie\.com)\/(?:watch\?v=|embed\/)?([a-z0-9\-\_\%]+)(\?[\S]*)*/i);
         var vimeo = src.match(/\/\/(?:www\.)?vimeo.com\/([0-9a-z\-_]+)/i);
         var dailymotion = src.match(/\/\/(?:www\.)?dai.ly\/([0-9a-z\-_]+)/i);
         var vk = src.match(/\/\/(?:www\.)?(?:vk\.com|vkontakte\.ru)\/(?:video_ext\.php\?)(.*)/i);


### PR DESCRIPTION
Youtube parameters like "start" are being cut off when the iframe is created. I wanted to add the start parameter to the URL to let the video start at a specific time. So the URL looks like this: https://youtu.be/1UdI_eoDPKQ?start=18

In this pull request I changed the code so that all the parameters in the URL are added to the iframe src.