### PR TITLE
Update lg-hash.js: Don't destroy location.pathname on destroy

### DIFF
--- a/modules/lg-hash.js
+++ b/modules/lg-hash.js
@@ -77,7 +77,7 @@
         // Reset to old hash value
         if (this.oldHash && this.oldHash.indexOf('lg=' + this.core.s.galleryId) < 0) {
             if (history.replaceState) {
-                history.replaceState(null, null, this.oldHash);
+                history.replaceState(null, null, window.location.pathname + window.location.search + this.oldHash);
             } else {
                 window.location.hash = this.oldHash;
             }


### PR DESCRIPTION
When I open the slider and there is a hash already, upon closing the slider I lose the location.pathname.