### PR TITLE
make lightgallery work in header when dom is ready

### DIFF
--- a/src/lightgallery.ts
+++ b/src/lightgallery.ts
@@ -167,6 +167,9 @@ export class LightGallery {
     }
 
     init(): void {
+        if ( null === this.settings.container ) {
+            this.settings.container = document.body;
+        }
         this.addSlideVideoInfo(this.galleryItems);
 
         this.buildStructure();


### PR DESCRIPTION
This is related to #993. If lightgallery is imported in a script that is used in `<head>` rather than in `<body>`, `settings.container` will be null, as the settings are initialized on import of the script not when lightgallery is called. This PR proposes a change to make it work as long as the dev wraps their script in some kind of DOMReady / window.load.

I do not know if this is the very best place to add but it has to be before or in `buildStructure`.