### PR TITLE
fix: call response.text() after fetch()

### DIFF
--- a/src/lgQuery.ts
+++ b/src/lgQuery.ts
@@ -306,9 +306,11 @@ export class lgQuery {
 
     // Does not support IE
     load(url: string): this {
-        fetch(url).then((res) => {
-            this.selector.innerHTML = res;
-        });
+        fetch(url)
+            .then((res) => res.text())
+            .then((html) => {
+                this.selector.innerHTML = html;
+            });
         return this;
     }
 


### PR DESCRIPTION
Promise returned by fetch() call resolves to Response structure that should
not be assigned directly to innerHTML. The fetched text can be obtained using
response.text() method that returns Promise<string>.