### PR TITLE
Use HTMLElement to remove the requirement on unsafe-inline style CSP

### DIFF
--- a/src/lg-utils.ts
+++ b/src/lg-utils.ts
@@ -371,11 +371,16 @@ const utils = {
         iframeMaxHeight: string,
         src?: string,
         iframeTitle?: string,
-    ): string {
+    ): HTMLElement {
         const title = iframeTitle ? 'title="' + iframeTitle + '"' : '';
-        return `<div class="lg-video-cont lg-has-iframe" style="width:${iframeWidth}; max-width:${iframeMaxWidth}; height: ${iframeHeight}; max-height:${iframeMaxHeight}">
-                    <iframe class="lg-object" frameborder="0" ${title} src="${src}"  allowfullscreen="true"></iframe>
-                </div>`;
+        const iframeDiv = document.createElement('div');
+        iframeDiv.classList.add('lg-video-cont', 'lg-has-iframe');
+        iframeDiv.style.width = iframeWidth;
+        iframeDiv.style.maxWidth = iframeMaxWidth;
+        iframeDiv.style.height = iframeHeight;
+        iframeDiv.style.maxHeight = iframeMaxHeight;
+        iframeDiv.innerHTML = `<iframe class="lg-object" frameborder="0" ${title} src="${src}"  allowfullscreen="true"></iframe>`;
+        return iframeDiv;
     },
 
     getImgMarkup(

--- a/src/lgQuery.ts
+++ b/src/lgQuery.ts
@@ -338,9 +338,13 @@ export class lgQuery {
         });
         return this;
     }
-    prepend(html: string): this {
+    prepend(html: string | HTMLElement): this {
         this._each((el: any) => {
-            el.insertAdjacentHTML('afterbegin', html);
+            if (typeof html === 'string') {
+                el.insertAdjacentHTML('afterbegin', html);
+            } else {
+                el.appendChild(html);
+            }
         });
         return this;
     }

--- a/src/plugins/share/lg-share.ts
+++ b/src/plugins/share/lg-share.ts
@@ -52,10 +52,20 @@ export default class Share {
     }
 
     setLgShareMarkup(): void {
-        this.core.$toolbar.append(
-            `<button type="button" aria-label="${this.settings.sharePluginStrings['share']}" aria-haspopup="true" aria-expanded="false" class="lg-share lg-icon">
-                <ul class="lg-dropdown" style="position: absolute;"></ul></button>`,
+        const shareBtn = document.createElement('button');
+        shareBtn.classList.add('lg-share', 'lg-icon');
+        shareBtn.type = 'button';
+        shareBtn.setAttribute(
+            'ariaLabel',
+            this.settings.sharePluginStrings['share'],
         );
+        shareBtn.setAttribute('ariaHasPopup', 'true');
+        shareBtn.setAttribute('ariaExpanded', 'false');
+        const shareBtnUl = document.createElement('ul');
+        shareBtnUl.classList.add('lg-dropdown');
+        shareBtnUl.style.position = 'absolute';
+        shareBtn.appendChild(shareBtnUl);
+        this.core.$toolbar.append(shareBtn);
 
         this.core.outer.append('<div class="lg-dropdown-overlay"></div>');
         const $shareButton = this.core.outer.find('.lg-share');

--- a/src/plugins/thumbnail/lg-thumbnail.ts
+++ b/src/plugins/thumbnail/lg-thumbnail.ts
@@ -406,7 +406,7 @@ export default class Thumbnail {
         return thumbDragUtils;
     }
 
-    getThumbHtml(thumb: string, index: number): string {
+    getThumbHtml(thumb: string, index: number): HTMLElement {
         const slideVideoInfo =
             this.core.galleryItems[index].__slideVideoInfo || {};
         let thumbImg;
@@ -426,29 +426,29 @@ export default class Thumbnail {
             thumbImg = thumb;
         }
 
-        return `<div data-lg-item-id="${index}" class="lg-thumb-item ${
-            index === this.core.index ? ' active' : ''
-        }" 
-        style="width:${this.settings.thumbWidth}px; height: ${
-            this.settings.thumbHeight
-        };
-            margin-right: ${this.settings.thumbMargin}px;">
-            <img data-lg-item-id="${index}" src="${thumbImg}" />
-        </div>`;
+        const thumbDiv = document.createElement('div');
+        thumbDiv.dataset['lg-item-id'] = index.toString();
+        thumbDiv.classList.add('lg-thumb-item');
+        thumbDiv.classList.toggle('active', index === this.core.index);
+        thumbDiv.style.width = `${this.settings.thumbWidth}px`;
+        thumbDiv.style.height = `${this.settings.thumbHeight}px`;
+        thumbDiv.style.marginRight = `${this.settings.thumbMargin}px`;
+        thumbDiv.innerHTML = `<img data-lg-item-id="${index}" src="${thumbImg}" />`;
+        return thumbDiv;
     }
 
-    getThumbItemHtml(items: ThumbnailGalleryItem[]): string {
-        let thumbList = '';
-        for (let i = 0; i < items.length; i++) {
-            thumbList += this.getThumbHtml(items[i].thumb, i);
-        }
-
+    getThumbItemHtml(items: ThumbnailGalleryItem[]): HTMLElement[] {
+        const thumbList: HTMLElement[] = [];
+        items.forEach((item, i) => {
+            thumbList.push(this.getThumbHtml(item.thumb, i));
+        });
         return thumbList;
     }
 
     setThumbItemHtml(items: ThumbnailGalleryItem[]): void {
         const thumbList = this.getThumbItemHtml(items);
-        this.$lgThumb.html(thumbList);
+        this.$lgThumb.empty();
+        thumbList.forEach((e) => this.$lgThumb.append(e));
     }
 
     setAnimateThumbStyles(): void {


### PR DESCRIPTION
When denying `style-src: 'unsafe-inline'` in Content-Security-Protection headers, some parts of LightGallery break such as thumbnails. This is problematic for websites trying to enforce secure CSP.

This patch tries to partially fix these issues by using HTMLElements where DOM elements are built using `style=` attribute.