### PR TITLE
Make initial zoom transform selector consistent

### DIFF
--- a/src/plugins/zoom/lg-zoom.ts
+++ b/src/plugins/zoom/lg-zoom.ts
@@ -415,7 +415,10 @@ export default class Zoom {
         const $dummyImage = this.core.outer
             .find('.lg-current .lg-dummy-img')
             .first();
-        const $imageWrap = $image.parent();
+        const $imageWrap = this.core
+            .getSlideItem(this.core.index)
+            .find('.lg-img-wrap')
+            .first();
         this.scale = style.scale;
         $image.css(
             'transform',


### PR DESCRIPTION
I have an issue where I'm using jQuery to insert HTML for an annotated overlay over the gallery images (this requires my own wrapper DIV to wrap the image and the annotations). Everything works fine except the zoom function. This is because the initial selector for the transform is based on the image parent, whereas everywhere else in the code, it directly selects the image wrap div.

I've changed this initial selector to select the image wrap div to be consistent with the rest of your code and this also fixes my issue. I thought I'd create this pull request incase you wanted to implement the fix as well.