### PR TITLE
fix: change order of YouTube player params

### DIFF
--- a/src/plugins/video/lg-video.ts
+++ b/src/plugins/video/lg-video.ts
@@ -235,13 +235,13 @@ export default class Video {
                 ? videoInfo.youtube[2] + '&'
                 : '';
             // For youtube first parms gets priority if duplicates found
-            const youTubePlayerParams = `?${slideUrlParams}wmode=opaque&autoplay=0&mute=1&enablejsapi=1`;
+            const defaultYouTubePlayerParams = `${slideUrlParams}wmode=opaque&autoplay=0&mute=1&enablejsapi=1`;
 
-            const playerParams =
-                youTubePlayerParams +
-                (this.settings.youTubePlayerParams
-                    ? '&' + param(this.settings.youTubePlayerParams)
-                    : '');
+            const playerParams = `?${
+                this.settings.youTubePlayerParams
+                    ? `${param(this.settings.youTubePlayerParams)}&`
+                    : ''
+            }${defaultYouTubePlayerParams}`;
 
             video = `<iframe allow="autoplay" id=${videoId} class="lg-video-object lg-youtube ${addClass}" ${videoTitle} src="//www.youtube.com/embed/${
                 videoInfo.youtube[1] + playerParams


### PR DESCRIPTION
As stated in the comment above in line 237, for YouTube the first param gets priority if duplicates are found, so we need to put custom player params before the default player params.