### PR TITLE
fix(types): allow partial element properties for VideoSource type

### DIFF
--- a/src/plugins/video/types.ts
+++ b/src/plugins/video/types.ts
@@ -3,6 +3,6 @@ export interface VideoSource {
         src: string;
         type: string;
     }[];
-    tracks: HTMLTrackElement[];
-    attributes: HTMLVideoElement;
+    tracks: Partial<HTMLTrackElement>[];
+    attributes: Partial<HTMLVideoElement>;
 }


### PR DESCRIPTION
Hello, first of all, thanks for the amazing package! 😊 

During testing implementation, I found out that the typings of `VideoSource` are very strict and are requiring you to define all properties of `HTMLVideoElement` and `HTMLTrackElement`. 

This means that when you want to declare only some of them, which is a common use case, it's throwing incorrect typings warnings. Such as:
![Screenshot 2022-11-04 at 08 36 04](https://user-images.githubusercontent.com/10739349/199918257-31a0e8d7-2a68-474b-9c32-0de5d4fb8fef.png)
![Screenshot 2022-11-04 at 08 36 13](https://user-images.githubusercontent.com/10739349/199918253-df3a4640-0c3e-412c-8575-668369307df9.png)


To resolve this and be able to use type-correct implementation I've updated those types to allow for `Partial` properties. 

Implementation of usage of those two properties is untouched and also supports these edited types.
- https://github.com/sachinchoolur/lightGallery/blob/c6f6d6c7b8c49dff12727c90dbaabed46a121f02/src/plugins/video/lg-video.ts#L287
- https://github.com/sachinchoolur/lightGallery/blob/c6f6d6c7b8c49dff12727c90dbaabed46a121f02/src/plugins/video/lg-video.ts#L278

I hope this will get merged so we can use our implementation type correctly. 

Thanks! 😊 
