### PR TITLE
fix(settings): fix selector type

### DIFF
--- a/src/lg-settings.ts
+++ b/src/lg-settings.ts
@@ -382,9 +382,9 @@ export interface LightGalleryCoreSettings {
      * @description Based on your markup structure, you can specify custom selectors to fetch media data for the gallery
      * Pass "this" to select same element
      * You can also pass HTMLCollection directly
-     * Example - '.my-selector' | '#my-selector' | this | document.querySelectorAll('.my-selector')
+     * Example - '.my-selector' | '#my-selector' | this | document.getElementsByClassName('my-selector') | document.querySelectorAll('.my-selector')
      */
-    selector: string | HTMLCollection[];
+    selector: string | HTMLCollection | NodeList;
 
     /**
      * By default selector element relative to the current gallery.


### PR DESCRIPTION
when `selector` is passed to a type other than `string`, `selector` is assigned directly to `items` (see code1), `items` requires its member to be of type `HTMLElement` (see code2).

### code1
https://github.com/sachinchoolur/lightGallery/blob/7219afe3ac320b92d2892e4e91d00bd6b5291983/src/lightgallery.ts#L560

### code2
https://github.com/sachinchoolur/lightGallery/blob/7219afe3ac320b92d2892e4e91d00bd6b5291983/src/lg-utils.ts#L525

---

if you insist on passing `HTMLCollection[]` types, an exception will be thrown.
```
ERROR TypeError: Cannot read properties of undefined (reading 'length')
    at lightgallery.es5.js:746:29
    at Array.forEach (<anonymous>)
    at Object.getDynamicOptions (lightgallery.es5.js:744:1)
    at LightGallery.getItems (lightgallery.es5.js:1179:1)
```
This is because the `item` type is `HTMLCollection`, which has no `attributes` (see code3).

### code3
https://github.com/sachinchoolur/lightGallery/blob/7219afe3ac320b92d2892e4e91d00bd6b5291983/src/lg-utils.ts#L527