### PR TITLE
fix: refactor inline styles in thumbnail plugin for CSP compatibility

### DIFF
--- a/src/lg-utils.ts
+++ b/src/lg-utils.ts
@@ -455,7 +455,7 @@ const utils = {
 
     getVideoPosterMarkup(
         _poster: string,
-        dummyImg: string,
+        dummyImg: string | HTMLElement,
         videoContStyle: string,
         playVideoString: string,
         _isVideo?: VideoInfo,

--- a/src/lgQuery.ts
+++ b/src/lgQuery.ts
@@ -338,9 +338,13 @@ export class lgQuery {
         });
         return this;
     }
-    prepend(html: string): this {
+    prepend(html: string | HTMLElement): this {
         this._each((el: any) => {
-            el.insertAdjacentHTML('afterbegin', html);
+            if (typeof html === 'string') {
+                el.insertAdjacentHTML('afterbegin', html);
+            } else if (html instanceof HTMLElement) {
+                el.insertBefore(html.cloneNode(true), el.firstChild);
+            }
         });
         return this;
     }

--- a/src/lightgallery.ts
+++ b/src/lightgallery.ts
@@ -950,7 +950,7 @@ export class LightGallery {
         $currentSlide: lgQuery,
         index: number,
         alt: string,
-    ): string {
+    ): HTMLImageElement | string {
         let $currentItem;
         if (!this.settings.dynamic) {
             $currentItem = $LG(this.items).eq(index);
@@ -964,12 +964,16 @@ export class LightGallery {
             }
             if (!_dummyImgSrc) return '';
             const imgStyle = this.getDummyImgStyles(this.currentImageSize);
-            const dummyImgContent = `<img ${alt} style="${imgStyle}" class="lg-dummy-img" src="${_dummyImgSrc}" />`;
+            const dummyImgContentImg = document.createElement('img');
+            dummyImgContentImg.alt = alt || '';
+            dummyImgContentImg.src = _dummyImgSrc;
+            dummyImgContentImg.className = `lg-dummy-img`;
+            dummyImgContentImg.style.cssText = imgStyle;
 
             $currentSlide.addClass('lg-first-slide');
             this.outer.addClass('lg-first-slide-loading');
 
-            return dummyImgContent;
+            return dummyImgContentImg;
         }
         return '';
     }
@@ -980,7 +984,7 @@ export class LightGallery {
 
         // Use the thumbnail as dummy image which will be resized to actual image size and
         // displayed on top of actual image
-        let imgContent = '';
+        let imgContent: string | HTMLImageElement = '';
         const altAttr = alt ? 'alt="' + alt + '"' : '';
 
         if (this.isFirstSlideWithZoomAnimation()) {
@@ -999,8 +1003,10 @@ export class LightGallery {
                 sources,
             );
         }
-        const imgMarkup = `<picture class="lg-img-wrap"> ${imgContent}</picture>`;
-        $currentSlide.prepend(imgMarkup);
+        const picture = document.createElement('picture');
+        picture.className = 'lg-img-wrap';
+        picture.append(imgContent);
+        $currentSlide.prepend(picture);
     }
 
     onSlideObjectLoad(
@@ -1180,7 +1186,7 @@ export class LightGallery {
                 );
                 $currentSlide.prepend(markup);
             } else if (poster) {
-                let dummyImg = '';
+                let dummyImg: string | HTMLImageElement = '';
                 const hasStartAnimation =
                     isFirstSlide &&
                     this.zoomFromOrigin &&

--- a/src/plugins/thumbnail/lg-thumbnail.ts
+++ b/src/plugins/thumbnail/lg-thumbnail.ts
@@ -406,7 +406,7 @@ export default class Thumbnail {
         return thumbDragUtils;
     }
 
-    getThumbHtml(thumb: string, index: number, alt?: string): string {
+    getThumbHtml(thumb: string, index: number, alt?: string): HTMLElement {
         const slideVideoInfo =
             this.core.galleryItems[index].__slideVideoInfo || {};
         let thumbImg;
@@ -426,31 +426,25 @@ export default class Thumbnail {
             thumbImg = thumb;
         }
 
-        const altAttr = alt ? 'alt="' + alt + '"' : '';
-
-        return `<div data-lg-item-id="${index}" class="lg-thumb-item ${
-            index === this.core.index ? ' active' : ''
-        }"
-        style="width:${this.settings.thumbWidth}px; height: ${
-            this.settings.thumbHeight
-        };
-            margin-right: ${this.settings.thumbMargin}px;">
-            <img ${altAttr} data-lg-item-id="${index}" src="${thumbImg}" />
-        </div>`;
-    }
-
-    getThumbItemHtml(items: ThumbnailGalleryItem[]): string {
-        let thumbList = '';
-        for (let i = 0; i < items.length; i++) {
-            thumbList += this.getThumbHtml(items[i].thumb, i, items[i].alt);
-        }
-
-        return thumbList;
+        const div = document.createElement('div');
+        div.setAttribute('data-lg-item-id', index + '');
+        div.className = `lg-thumb-item ${
+            index === this.core.index ? 'active' : ''
+        }`;
+        div.style.cssText = `width: ${this.settings.thumbWidth}px; height: ${this.settings.thumbHeight}; margin-right: ${this.settings.thumbMargin}px;`;
+        const img = document.createElement('img');
+        img.alt = alt || '';
+        img.setAttribute('data-lg-item-id', index + '');
+        img.src = thumbImg;
+        div.appendChild(img);
+        return div;
     }
 
     setThumbItemHtml(items: ThumbnailGalleryItem[]): void {
-        const thumbList = this.getThumbItemHtml(items);
-        this.$lgThumb.html(thumbList);
+        for (let i = 0; i < items.length; i++) {
+            const thumb = this.getThumbHtml(items[i].thumb, i, items[i].alt);
+            this.$lgThumb.append(thumb);
+        }
     }
 
     setAnimateThumbStyles(): void {


### PR DESCRIPTION
**Problem:**

If we add Content-Security-Policy in the <head> of our HTML file currently restricts inline styles with the directive style-src 'self';. This leads to a scenario where thumbnail images that rely on inline styling do not render correctly.

**Visual Proof of Issue:**

<img width="1676" alt="Screenshot 2023-11-24 at 3 26 37 PM" src="https://github.com/sachinchoolur/lightGallery/assets/121571713/3986ef58-2d40-44c7-b9e2-8e7dec4af6f0">
