### PR TITLE
Ignore click events on data-lg-ignore elements

### DIFF
--- a/src/lightgallery.ts
+++ b/src/lightgallery.ts
@@ -222,6 +222,14 @@ export class LightGallery {
             $element
                 .attr('data-lg-id', uuid)
                 .on(`click.lgcustom-item-${uuid}`, (e) => {
+                    // Ignore if clicked on element with data-lg-ignore attribute.
+                    if (
+                        e.target instanceof Element &&
+                        e.target.closest("[data-lg-ignore=true]")
+                    ) {
+                        return;
+                    }
+
                     e.preventDefault();
                     const currentItemIndex = this.settings.index || index;
                     this.openGallery(currentItemIndex, element);


### PR DESCRIPTION
This gives users the ability to have elements within an item not open the gallery, such as overlayed trash/copy/share icons.

Fixes #1613