### PR TITLE
zoom touchstart event.target not the same

### DIFF
--- a/src/plugins/zoom/lg-zoom.ts
+++ b/src/plugins/zoom/lg-zoom.ts
@@ -528,9 +528,14 @@ export default class Zoom {
             }
             this.setActualSize(this.core.index, event);
         });
-
+        let preTarget: any = null
         this.core.outer.on('touchstart.lg', (event) => {
             const $target = this.$LG(event.target);
+            if (preTarget && preTarget !== event.target) {
+				clearTimeout(tapped as ReturnType<typeof setTimeout>)
+				tapped = null
+			}
+			preTarget = event.target
             if (event.touches.length === 1 && $target.hasClass('lg-image')) {
                 if (!tapped) {
                     tapped = setTimeout(() => {


### PR DESCRIPTION
# Question
my business requires images to slide quickly, so i set it `speed: 0` , When I run it, it triggers the zoom by mistake

This is my test project：https://github.com/coderlyu/lightGallery-fase-swipe

the effect of error:

https://github.com/sachinchoolur/lightGallery/assets/56467425/65da5ae4-874e-45d3-be56-257efc89fdbc


the video clips，you can see that the previous picture is enlarged：
<img width="405" alt="zoom_err_snipaste" src="https://github.com/sachinchoolur/lightGallery/assets/56467425/12bbf436-03a6-48bf-8d04-51e83a5602a0">

the effect I expect：

https://github.com/sachinchoolur/lightGallery/assets/56467425/c8d5123a-083d-4f72-8368-e1d5f345045f

