### PR TITLE
zoom touchstart event.target not the same

### DIFF
--- a/src/plugins/zoom/lg-zoom.ts
+++ b/src/plugins/zoom/lg-zoom.ts
@@ -528,9 +528,14 @@ export default class Zoom {
             }
             this.setActualSize(this.core.index, event);
         });
-
+        let preTarget: any = null
         this.core.outer.on('touchstart.lg', (event) => {
             const $target = this.$LG(event.target);
+            if (preTarget && preTarget !== event.target) {
+				clearTimeout(tapped as ReturnType<typeof setTimeout>)
+				tapped = null
+			}
+			preTarget = event.target
             if (event.touches.length === 1 && $target.hasClass('lg-image')) {
                 if (!tapped) {
                     tapped = setTimeout(() => {


### PR DESCRIPTION
# Question

my business requires images to slide quickly, so i set it `speed: 0` , When I run it, it triggers the zoom by mistake

this is my test project：https://github.com/coderlyu/lightGallery-fase-swipe

the effect of error:

https://github.com/sachinchoolur/lightGallery/assets/56467425/bc0bd1da-337b-4fc9-a527-79da3f3585ab


the video clips，you can see that the previous picture is enlarged：
<img width="405" alt="zoom_err_snipaste" src="https://github.com/sachinchoolur/lightGallery/assets/56467425/49d9a387-d1dc-4c31-abfb-57c28ba69441">


the effect I expect：

https://github.com/sachinchoolur/lightGallery/assets/56467425/64a41e13-de49-44d4-8db2-8d83a2dd93a1

