### PR TITLE
Fix SASS deprecation warning

### DIFF
--- a/src/scss/lg-autoplay.scss
+++ b/src/scss/lg-autoplay.scss
@@ -31,10 +31,10 @@
 
 .lg-autoplay-button {
     &:after {
+        content: '\e01d';
         .lg-show-autoplay & {
             content: '\e01a';
         }
-        content: '\e01d';
     }
     .lg-single-item & {
         opacity: $lg-toolbar-icon-disabled-opacity;

--- a/src/scss/lightgallery-core.scss
+++ b/src/scss/lightgallery-core.scss
@@ -157,11 +157,11 @@
     }
 
     .lg-item {
+        display: none !important;
         &:not(.lg-start-end-progress) {
             background: url('#{$lg-path-images}/loading.gif') no-repeat scroll
                 center center transparent;
         }
-        display: none !important;
     }
     &.lg-css3 {
         .lg-prev-slide,


### PR DESCRIPTION
Hey, these small changes fix SASS deprecated warnings as mentioned in #1657 and #1647 

```
Deprecation Warning on line 36, column 8 of
│ │ node_modules/lightgallery/scss/lg-autoplay.scss:36:8:
│ │ Sass's behavior for declarations that appear after nested
│ │ rules will be changing to match the behavior specified by CSS in an
│ │ upcoming
│ │ version. To keep the existing behavior, move the declaration above the
│ │ nested
│ │ rule. To opt into the new behavior, wrap the declaration in `& {}`.
│ │ More info: https://sass-lang.com/d/mixed-decls
│ │ 36 |         content: '/e01d';
│ │ node_modules/lightgallery/scss/lg-autoplay.scss 37:9          @import
│ │ node_modules/lightgallery/scss/lightgallery-bundle.scss 23:9  @import
│ │ resources/styles/lightgallery.scss 16:9                       root
│ │ stylesheet
```
and 
```
│ │ Deprecation Warning on line 163, column 8 of
│ │ node_modules/lightgallery/scss/lightgallery-core.scss:163:8:
│ │ Sass's behavior for declarations that appear after nested
│ │ rules will be changing to match the behavior specified by CSS in an
│ │ upcoming
│ │ version. To keep the existing behavior, move the declaration above the
│ │ nested
│ │ rule. To opt into the new behavior, wrap the declaration in `& {}`.
│ │ More info: https://sass-lang.com/d/mixed-decls
│ │ 163 |         display: none !important;
│ │ node_modules/lightgallery/scss/lightgallery-core.scss 164:9   @import
│ │ node_modules/lightgallery/scss/lightgallery-bundle.scss 34:9  @import
│ │ resources/styles/lightgallery.scss 16:9                       root
│ │ stylesheet
```