### PR TITLE
fix: remove debug log

### DIFF
--- a/src/lg-utils.ts
+++ b/src/lg-utils.ts
@@ -579,7 +579,6 @@ const utils = {
             dynamicEl.alt = alt || title || '';
             dynamicElements.push(dynamicEl);
         });
-        console.log(dynamicElements, 'dynamicElements');
         return dynamicElements;
     },
     isMobile(): boolean {


### PR DESCRIPTION
## Summary

After upgrading to v2.8.1, I noticed this log started printing whenever a gallery was created.  It looks like it was used for debugging in https://github.com/sachinchoolur/lightGallery/pull/1603 and was never removed.