### PR TITLE
fix(lg-zoom): avoid reference error when `containerRect` in not defined

### DIFF
--- a/src/plugins/zoom/lg-zoom.ts
+++ b/src/plugins/zoom/lg-zoom.ts
@@ -188,7 +188,7 @@ export default class Zoom {
         reposition: boolean,
         resetToMax: boolean,
     ): void {
-        if (Math.abs(scaleDiff) <= 0) return;
+        if (!this.containerRect || Math.abs(scaleDiff) <= 0) return;
 
         const offsetX = this.containerRect.width / 2 + this.containerRect.left;
 


### PR DESCRIPTION
This PR adds an additional early exit condition to the `zoomImage()` method, when `containerRect` is not defined.

Closes #1485