### PR TITLE
Fix: Sanitize YouTube No-Cookie URL by Validating Hostname

### DIFF
--- a/src/plugins/video/lg-video-utils.ts
+++ b/src/plugins/video/lg-video-utils.ts
@@ -55,7 +55,12 @@ export const getYouTubeParams = (
 };
 
 export const isYouTubeNoCookie = (url: string): boolean => {
-    return url.includes('youtube-nocookie.com');
+    try {
+        const parsedUrl = new URL(url);
+        return parsedUrl.host === 'youtube-nocookie.com';
+    } catch (e) {
+        return false;
+    }
 };
 
 export const getVimeoURLParams = (


### PR DESCRIPTION
## Problem

The current implementation of `isYouTubeNoCookie(url)` uses a substring check:

```js
return url.includes('youtube-nocookie.com');
```

This is unsafe because `youtube-nocookie.com` can appear anywhere in the string, including in malicious or misleading URLs such as: `https://attacker.com/youtube-nocookie.com.fake.site`
This would incorrectly pass the check, even though the host is not `youtube-nocookie.com`.

## Solution
This PR improves the validation by parsing the URL with the URL constructor and comparing the host value directly:

```js
var isYouTubeNoCookie = function (url) {
    try {
        var parsedUrl = new URL(url);
        return parsedUrl.host === 'youtube-nocookie.com';
    } catch (e) {
        return false; // Fails safely if the URL is invalid
    }
};
```
This ensures the function only returns true for valid URLs that have an exact hostname match.

## Benefits
✅ Prevents false positives on malicious or incorrectly formatted URLs
✅ Improves security by relying on structured URL parsing
✅ Passes CodeQL analysis and aligns with secure coding practices
✅ Makes the plugin more robust and reliable

