### PR TITLE
feat(thumbnail): Lazy load thumbnails

### DIFF
--- a/src/lg-utils.ts
+++ b/src/lg-utils.ts
@@ -579,7 +579,6 @@ const utils = {
             dynamicEl.alt = alt || title || '';
             dynamicElements.push(dynamicEl);
         });
-        console.log(dynamicElements, 'dynamicElements');
         return dynamicElements;
     },
     isMobile(): boolean {

--- a/src/plugins/thumbnail/lg-thumbnail-settings.ts
+++ b/src/plugins/thumbnail/lg-thumbnail-settings.ts
@@ -84,6 +84,11 @@ export interface ThumbnailsSettings {
      * Custom translation strings for aria-labels
      */
     thumbnailPluginStrings: ThumbnailStrings;
+
+    /**
+     * Enables thumbnail lazy loading when in view
+     */
+    thumbnailLazyLoad: boolean;
 }
 
 export const thumbnailsSettings: ThumbnailsSettings = {
@@ -106,6 +111,8 @@ export const thumbnailsSettings: ThumbnailsSettings = {
 
     loadYouTubeThumbnail: true,
     youTubeThumbSize: 1,
+
+    thumbnailLazyLoad: false,
 
     thumbnailPluginStrings: {
         toggleThumbnails: 'Toggle thumbnails',


### PR DESCRIPTION
Load thumbnails only when visible using the Intersection Observer API.

Solves https://github.com/sachinchoolur/lightGallery/issues/965

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an option to enable lazy loading for gallery thumbnails, improving performance by loading images only as they come into view.

* **Bug Fixes**
  * Removed an unnecessary debugging message from the console output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->