### PR TITLE
docs: broken link in site/content/demos/thumbnails.md

### DIFF
--- a/site/content/demos/thumbnails.md
+++ b/site/content/demos/thumbnails.md
@@ -7,7 +7,7 @@ lead:
     allows users to navigate between slides by clicking on the thumbnails.
     Thumbnails plugin also allows you to load thumbnails automatically for
     YouTube, Vimeo, and other video sources. Find out more options in the <a
-    href="../../docs/options/#thumbnails-plugin"> docs </a>'
+    href="/docs/settings/#thumbnails-plugin"> docs </a>'
 date: 2020-10-06T08:48:57+00:00
 draft: false
 images: []


### PR DESCRIPTION
Link to lightgallery options was set to
../../docs/options/#thumbnails-plugin

It is now fixed as /docs/settings/#thumbnails-plugin, using similar link as the ones in react-video-gallery.md and video-gallery.md