### PR TITLE
fix: grab only unmodified esc/leftarrow/rightarrow

### DIFF
--- a/src/lightgallery.ts
+++ b/src/lightgallery.ts
@@ -2132,10 +2132,17 @@ export class LightGallery {
 
     keyPress(): void {
         $LG(window).on(`keydown.lg.global${this.lgId}`, (e) => {
+            const noModifier = !(
+                e.altKey ||
+                e.ctrlKey ||
+                e.metaKey ||
+                e.shiftKey
+            );
             if (
                 this.lgOpened &&
                 this.settings.escKey === true &&
-                e.keyCode === 27
+                e.key === 'Escape' &&
+                noModifier
             ) {
                 e.preventDefault();
                 if (
@@ -2149,12 +2156,12 @@ export class LightGallery {
                 }
             }
             if (this.lgOpened && this.galleryItems.length > 1) {
-                if (e.keyCode === 37) {
+                if (e.key === 'ArrowLeft' && noModifier) {
                     e.preventDefault();
                     this.goToPrevSlide();
                 }
 
-                if (e.keyCode === 39) {
+                if (e.key === 'ArrowRight' && noModifier) {
                     e.preventDefault();
                     this.goToNextSlide();
                 }


### PR DESCRIPTION
This avoid hijacking for example Alt-Left, which is typically Back in
the browser. lightGallery only uses the plain Esc, LeftArrow, RightArrow
keys, and should not grab them with any modifiers.

We now also use the KeyboardEvent.key property, instead of the
deprecated keyCode. The key property has been available across browsers
since 2017. Ref:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

Closes https://github.com/sachinchoolur/lightGallery/issues/1732

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation in the light gallery for more reliable cross-browser behavior.
  * Left/Right arrows now change slides only when no modifier keys (Alt, Ctrl, Meta, Shift) are pressed, avoiding OS/browser shortcut conflicts.
  * Escape now consistently closes the gallery only when no modifier keys are held.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->