### PR TITLE
fix: escape HTML attributes to prevent XSS attacks

### DIFF
--- a/src/lg-utils.ts
+++ b/src/lg-utils.ts
@@ -388,6 +388,20 @@ const utils = {
         return transform;
     },
 
+    /**
+     * Escapes HTML attribute values to prevent XSS attacks
+     * @param {string} value - The attribute value to escape
+     * @returns {string} The escaped attribute value
+     */
+    escapeHtml(value: string): string {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#x27;');
+    },
+
     getIframeMarkup(
         iframeWidth: string,
         iframeHeight: string,
@@ -396,7 +410,9 @@ const utils = {
         src?: string,
         iframeTitle?: string,
     ): string {
-        const title = iframeTitle ? 'title="' + iframeTitle + '"' : '';
+        const title = iframeTitle
+            ? 'title="' + this.escapeHtml(iframeTitle) + '"'
+            : '';
         return `<div class="lg-media-cont lg-has-iframe" style="width:${iframeWidth}; max-width:${iframeMaxWidth}; height: ${iframeHeight}; max-height:${iframeMaxHeight}">
                     <iframe class="lg-object" frameborder="0" ${title} src="${src}"  allowfullscreen="true"></iframe>
                 </div>`;
@@ -410,8 +426,8 @@ const utils = {
         sizes?: string,
         sources?: ImageSources[],
     ): string {
-        const srcsetAttr = srcset ? `srcset="${srcset}"` : '';
-        const sizesAttr = sizes ? `sizes="${sizes}"` : '';
+        const srcsetAttr = srcset ? `srcset="${this.escapeHtml(srcset)}"` : '';
+        const sizesAttr = sizes ? `sizes="${this.escapeHtml(sizes)}"` : '';
         const imgMarkup = `<img ${altAttr} ${srcsetAttr}  ${sizesAttr} class="lg-object lg-image" data-index="${index}" src="${src}" />`;
         let sourceTag = '';
         if (sources) {
@@ -574,7 +590,11 @@ const utils = {
             dynamicEl.thumb = thumb;
 
             if (getCaptionFromTitleOrAlt && !dynamicEl.subHtml) {
-                dynamicEl.subHtml = title || alt || '';
+                // Escape HTML when using title/alt as caption to prevent XSS
+                const captionText = title || alt || '';
+                dynamicEl.subHtml = captionText
+                    ? this.escapeHtml(captionText)
+                    : '';
             }
             dynamicEl.alt = alt || title || '';
             dynamicElements.push(dynamicEl);

--- a/src/lightgallery.ts
+++ b/src/lightgallery.ts
@@ -1004,13 +1004,13 @@ export class LightGallery {
         // Use the thumbnail as dummy image which will be resized to actual image size and
         // displayed on top of actual image
         let imgContent: string | HTMLImageElement = '';
-        const altAttr = alt ? 'alt="' + alt + '"' : '';
+        const altAttr = alt ? 'alt="' + utils.escapeHtml(alt) + '"' : '';
 
         if (this.isFirstSlideWithZoomAnimation()) {
             imgContent = this.getDummyImageContent(
                 $currentSlide,
                 index,
-                altAttr,
+                alt || '',
             );
         } else {
             imgContent = utils.getImgMarkup(

--- a/test/lightgallery.test.ts
+++ b/test/lightgallery.test.ts
@@ -302,3 +302,222 @@ describe('Plugins', () => {
         expect(LG.galleryItems[0].poster).toBeUndefined();
     });
 });
+
+describe('Security - XSS Prevention', () => {
+    it('Should escape double quotes in alt attribute to prevent attribute breakout', async () => {
+        // Test: Double quote to break out of attribute and inject malicious HTML
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" alt='"><img src=x onerror=alert(1)>' />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                const altValue = lgObject.getAttribute('alt');
+                expect(altValue).toBe('"><img src=x onerror=alert(1)>');
+            }
+
+            // Verify no malicious img was injected
+            const xssImg = document.querySelector('img[src="x"]');
+            expect(xssImg).toBeNull();
+        });
+
+        LG.destroy();
+    });
+
+    it('Should escape double quotes in alt to prevent event handler injection', async () => {
+        // Test: Inject onload event handler
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" alt='" onload="alert(1)" x="' />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                const altValue = lgObject.getAttribute('alt');
+                expect(altValue).toBe('" onload="alert(1)" x="');
+
+                // The onload should not be an actual attribute
+                expect(lgObject.hasAttribute('onload')).toBe(false);
+            }
+        });
+
+        LG.destroy();
+    });
+
+    it('Should escape double quotes in alt to prevent script injection', async () => {
+        // Test: Script tag injection
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" alt='"><script>alert("XSS")</script><img x="' />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            // No script tags should be injected
+            const scripts = document.querySelectorAll('.lg-item script');
+            expect(scripts.length).toBe(0);
+        });
+
+        LG.destroy();
+    });
+
+    it('Should handle ampersands in alt without double-encoding', async () => {
+        // Test: Special HTML characters
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" alt="Testing &amp; signs &lt; and &gt; symbols" />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                const altValue = lgObject.getAttribute('alt');
+                // Browser automatically decodes HTML entities in attributes
+                expect(altValue).toBe('Testing & signs < and > symbols');
+            }
+        });
+
+        LG.destroy();
+    });
+
+    it('Should handle single quotes in alt attribute', async () => {
+        // Test: Single quotes (less dangerous but should still work)
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" alt="It's a nice image with 'quotes'" />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                const altValue = lgObject.getAttribute('alt');
+                expect(altValue).toBe("It's a nice image with 'quotes'");
+            }
+        });
+
+        LG.destroy();
+    });
+
+    it('Should escape double quotes in srcset attribute', async () => {
+        // Test: Srcset attribute vulnerability
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" srcset='" onload="alert(1)" x="' />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                // Should not have onload as an actual attribute
+                expect(lgObject.hasAttribute('onload')).toBe(false);
+            }
+        });
+
+        LG.destroy();
+    });
+
+    it('Should escape double quotes in sizes attribute', async () => {
+        // Test: Sizes attribute vulnerability
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" sizes='" onload="alert(1)" x="' />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                // Should not have onload as an actual attribute
+                expect(lgObject.hasAttribute('onload')).toBe(false);
+            }
+        });
+
+        LG.destroy();
+    });
+
+    it('Should handle backslashes and special characters in alt', async () => {
+        // Test: Various escape characters
+        document.body.innerHTML = `<div id="lightGallery">
+                <a href="a.png">
+                    <img src="b.png" alt='Test \\ backslash and "quotes" and <tags>' />
+                </a>
+            </div>`;
+
+        const LG = lightGallery(
+            document.getElementById('lightGallery') as HTMLElement,
+        );
+        LG.openGallery(0);
+
+        await waitFor(() => {
+            const lgObject = document.querySelector('.lg-object');
+            expect(lgObject).toBeInTheDocument();
+
+            if (lgObject) {
+                const altValue = lgObject.getAttribute('alt');
+                // Should preserve the content as-is
+                expect(altValue).toContain('backslash');
+                expect(altValue).toContain('quotes');
+            }
+        });
+
+        LG.destroy();
+    });
+});


### PR DESCRIPTION
This fixes a critical XSS vulnerability where unescaped double quotes in the `alt` attribute allow attackers to break out of the attribute context and inject malicious HTML/JavaScript (e.g., `"><img src=x onerror=alert(1)>`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security by escaping HTML content in image attributes, iframe titles, and dynamic captions to prevent injection attacks.

* **Tests**
  * Added comprehensive test suite validating XSS prevention across multiple scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->